### PR TITLE
Add React+Node web interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+# Build artifacts
+*.o
+encrypt_decrypt
+cryption
+
+# Node
+node_modules/
+frontend/node_modules/
+backend/node_modules/
+
+# Logs
+npm-debug.log*
+
+# IDE
+.vscode/

--- a/README.md
+++ b/README.md
@@ -175,3 +175,29 @@ Outputs are written alongside originals as `*.enc` or `*.dec` extensions.
 4. Open a PR against `main`
 
 Please adhere to the existing code style and add tests in `test/`!
+
+---
+
+## 🌐 Web Interface (Localhost)
+
+A simple React + Node implementation is provided in `frontend/` and `backend/`.
+
+### Setup
+
+1. **Backend**
+   ```bash
+   cd backend
+   npm install    # requires internet access
+   npm start
+   ```
+   The server listens on `http://localhost:3000` and exposes `/encrypt` and `/decrypt` endpoints.
+
+2. **Frontend**
+   ```bash
+   cd frontend
+   npm install    # requires internet access
+   npm run dev
+   ```
+   Visit `http://localhost:5173` in your browser. Sign in via Clerk and upload files to encrypt or decrypt.
+
+Both folders are optional and do not affect the C++ CLI.

--- a/backend/index.js
+++ b/backend/index.js
@@ -1,0 +1,43 @@
+import express from 'express';
+import multer from 'multer';
+import cors from 'cors';
+import { createCipheriv, createDecipheriv, randomBytes } from 'crypto';
+import fs from 'fs';
+
+const app = express();
+app.use(cors());
+const upload = multer({ dest: 'uploads/' });
+
+const ALGORITHM = 'aes-256-cbc';
+const KEY = randomBytes(32); // For demo only. Use persistent key in production
+const IV = randomBytes(16);
+
+function encrypt(buffer) {
+  const cipher = createCipheriv(ALGORITHM, KEY, IV);
+  return Buffer.concat([cipher.update(buffer), cipher.final()]);
+}
+
+function decrypt(buffer) {
+  const decipher = createDecipheriv(ALGORITHM, KEY, IV);
+  return Buffer.concat([decipher.update(buffer), decipher.final()]);
+}
+
+app.post('/encrypt', upload.single('file'), (req, res) => {
+  const data = fs.readFileSync(req.file.path);
+  const encrypted = encrypt(data);
+  fs.unlinkSync(req.file.path);
+  res.setHeader('Content-Disposition', `attachment; filename="${req.file.originalname}.enc"`);
+  res.end(encrypted);
+});
+
+app.post('/decrypt', upload.single('file'), (req, res) => {
+  const data = fs.readFileSync(req.file.path);
+  const decrypted = decrypt(data);
+  fs.unlinkSync(req.file.path);
+  res.setHeader('Content-Disposition', `attachment; filename="${req.file.originalname.replace(/\\.enc$/, '')}.dec"`);
+  res.end(decrypted);
+});
+
+app.listen(3000, () => {
+  console.log('Backend running on http://localhost:3000');
+});

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "file-encryptor-backend",
+  "version": "1.0.0",
+  "main": "index.js",
+  "type": "module",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "express": "^4.18.0",
+    "multer": "^1.4.5",
+    "cors": "^2.8.5"
+  }
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>File Encryptor</title>
+    <link rel="stylesheet" href="/src/index.css" />
+  </head>
+  <body class="bg-gray-100">
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "file-encryptor-frontend",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "@clerk/clerk-react": "^4.0.0",
+    "gsap": "^3.12.0"
+  },
+  "devDependencies": {
+    "vite": "^4.2.0",
+    "@vitejs/plugin-react": "^4.0.0",
+    "tailwindcss": "^3.4.0",
+    "postcss": "^8.4.0",
+    "autoprefixer": "^10.4.0"
+  }
+}

--- a/frontend/postcss.config.cjs
+++ b/frontend/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { SignedIn, SignedOut, SignInButton, UserButton } from '@clerk/clerk-react';
+import { gsap } from 'gsap';
+import UploadView from './components/UploadView';
+
+export default function App() {
+  React.useEffect(() => {
+    gsap.from('#title', { opacity: 0, y: -20, duration: 1 });
+  }, []);
+
+  return (
+    <div className="min-h-screen flex flex-col items-center p-8">
+      <h1 id="title" className="text-3xl font-bold mb-6">File Encryptor</h1>
+      <SignedOut>
+        <SignInButton mode="modal">
+          <button className="px-4 py-2 bg-blue-500 text-white rounded">Sign In</button>
+        </SignInButton>
+      </SignedOut>
+      <SignedIn>
+        <div className="self-end mb-4">
+          <UserButton />
+        </div>
+        <UploadView />
+      </SignedIn>
+    </div>
+  );
+}

--- a/frontend/src/components/HowItWorks.jsx
+++ b/frontend/src/components/HowItWorks.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { gsap } from 'gsap';
+
+export default function HowItWorks() {
+  React.useEffect(() => {
+    gsap.from('#how-title', { opacity: 0, y: 10, duration: 0.5 });
+  }, []);
+
+  return (
+    <div className="mt-8 p-4 bg-gray-50 rounded shadow text-sm">
+      <h2 id="how-title" className="text-xl font-semibold mb-2">How it Works</h2>
+      <ol className="list-decimal ml-4 space-y-1">
+        <li>Upload a text file.</li>
+        <li>The server encrypts it using AES-256-CBC.</li>
+        <li>Download the encrypted file and keep it safe.</li>
+        <li>You can also decrypt previously encrypted files.</li>
+      </ol>
+    </div>
+  );
+}

--- a/frontend/src/components/UploadView.jsx
+++ b/frontend/src/components/UploadView.jsx
@@ -1,0 +1,77 @@
+import React, { useState } from 'react';
+import HowItWorks from './HowItWorks';
+
+export default function UploadView() {
+  const [file, setFile] = useState(null);
+  const [message, setMessage] = useState('');
+  const [processing, setProcessing] = useState(false);
+
+  const handleEncrypt = async () => {
+    if (!file) return;
+    setProcessing(true);
+    const formData = new FormData();
+    formData.append('file', file);
+    const res = await fetch('http://localhost:3000/encrypt', {
+      method: 'POST',
+      body: formData
+    });
+    const blob = await res.blob();
+    setProcessing(false);
+    setMessage('File encrypted');
+    downloadBlob(blob, file.name + '.enc');
+  };
+
+  const handleDecrypt = async () => {
+    if (!file) return;
+    setProcessing(true);
+    const formData = new FormData();
+    formData.append('file', file);
+    const res = await fetch('http://localhost:3000/decrypt', {
+      method: 'POST',
+      body: formData
+    });
+    const blob = await res.blob();
+    setProcessing(false);
+    setMessage('File decrypted');
+    downloadBlob(blob, file.name.replace(/\.enc$/, '.dec'));
+  };
+
+  const downloadBlob = (blob, filename) => {
+    const url = window.URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    a.click();
+    window.URL.revokeObjectURL(url);
+  };
+
+  return (
+    <div className="w-full max-w-md bg-white p-6 rounded shadow">
+      <div className="mb-4">
+        <input
+          type="file"
+          accept=".txt,.enc"
+          onChange={(e) => setFile(e.target.files[0])}
+          className="w-full"
+        />
+      </div>
+      <div className="flex justify-between">
+        <button
+          onClick={handleEncrypt}
+          className="px-4 py-2 bg-green-500 text-white rounded"
+        >
+          Encrypt
+        </button>
+        <button
+          onClick={handleDecrypt}
+          className="px-4 py-2 bg-indigo-500 text-white rounded"
+        >
+          Decrypt
+        </button>
+      </div>
+      {processing && <p className="mt-4 text-sm text-gray-500">Processing...</p>}
+      {message && <p className="mt-2 text-sm text-green-700">{message}</p>}
+      <HowItWorks />
+    </div>
+  );
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { ClerkProvider } from '@clerk/clerk-react';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <ClerkProvider publishableKey="YOUR_CLERK_PUBLISHABLE_KEY">
+      <App />
+    </ClerkProvider>
+  </React.StrictMode>
+);

--- a/frontend/tailwind.config.cjs
+++ b/frontend/tailwind.config.cjs
@@ -1,0 +1,10 @@
+module.exports = {
+  content: [
+    './index.html',
+    './src/**/*.{js,jsx,ts,tsx}'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173
+  }
+});


### PR DESCRIPTION
## Summary
- add frontend React app with Tailwind, GSAP and Clerk
- add Node backend exposing encrypt/decrypt endpoints
- document how to run the web interface locally
- ignore build artifacts

## Testing
- `make`
- `make clean`


------
https://chatgpt.com/codex/tasks/task_e_6864d199f2c48325b51ea6bc00b38644